### PR TITLE
Changed center layout to have fluid header container

### DIFF
--- a/_layouts/center.html
+++ b/_layouts/center.html
@@ -2,9 +2,12 @@
 <html>
 {% include head.html %}
 <body>
-  <div class="container">
-    {% include header.html %}
 
+  <div class="container-fluid">
+      {% include header.html %}
+  </div>
+
+  <div class="container">
     <div class="post" role="main">
       <div class="">
         {{ content }}


### PR DESCRIPTION
Header layout on 404 uses center layout, which did not have a fluid container for the header.