### PR TITLE
Added Travis CI requirements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ _site
 
 # Ignore the config file that's used for gh-pages.
 _config.gh-pages.yml
+Gemfile.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: ruby
+rvm:
+- 2.1
+script:
+- rake test
+env:
+  global:
+  - NOKOGIRI_USE_SYSTEM_LIBRARIES=true

--- a/404.md
+++ b/404.md
@@ -5,13 +5,13 @@ permalink: /404.html
 
 # 404
 <div>
-<img src="/images/hexagons_small.png"/ style="float: right">
+<img src="/images/hexagons_small.png"/ style="float: right" alt="small hexagon">
 <q>Frustrating. I had Tron almost ready when Dillinger cut everyone with Group-7 access out of the system. I tell you ever since he got that Master Control Program, the system's got more bugs than a bait store.</q>
 </div>
 
 <p>
 <div class="mt3">
   <a href="/" class="button button-blue button-big">Home</a>
-  <a href="/contact/" class="button button-blue button-big">Contact</a>
+  <a href="/get-involved/" class="button button-blue button-big">Get involved</a>
 </div>
 </p>

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source 'https://rubygems.org'
+gem 'github-pages'
+gem 'html-proofer'

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Met Office Lab Jekyll Blog
+# Met Office Lab Jekyll Blog [![Build Status](https://travis-ci.org/met-office-lab/met-office-lab.github.io.svg)](https://travis-ci.org/met-office-lab/met-office-lab.github.io)
 
 This will be the blog for the Met Office Lab.
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,8 @@
+task :test do
+  sh "bundle exec jekyll build"
+  sh "bundle exec htmlproof ./_site --only-4xx"
+end
+
+task :serve do
+  sh "bundle exec jekyll serve"
+end

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -3,7 +3,7 @@
       <picture>
         <!-- this picture block can be used for art direction i.e. changing image with view size -->
         <source media="(min-width: 50em)" srcset="/images/header-2.png" class="img-responsive"/>
-        <img src="/images/header-2.png" class="img-responsive"/>
+        <img src="/images/header-2.png" class="img-responsive" alt="header"/>
       </picture>
     </a>
     <div>

--- a/_includes/pagination.html
+++ b/_includes/pagination.html
@@ -2,7 +2,7 @@
   {% if paginator.next_page %}
     <li class="previous"><a class="pagination-item" href="{{ site.baseurl }}/page{{paginator.next_page}}/">Older</a></li>
   {% else %}
-    <li class="previous disabled"><a class="pagination-item">Older</a></li>
+    <li class="previous disabled"><span class="pagination-item">Older</span></li>
   {% endif %}
 
   {% if paginator.previous_page %}
@@ -12,6 +12,6 @@
       <li class="next"><a class="pagination-item" href="{{ site.baseurl }}/page{{paginator.previous_page}}/">Newer</a></li>
       {% endif %}
   {% else %}
-    <li class="next disabled"><a class="pagination-item">Newer</a></li>
+    <li class="next disabled"><span class="pagination-item">Newer</span></li>
   {% endif %}
 </ul>

--- a/who-we-are/index.html
+++ b/who-we-are/index.html
@@ -6,7 +6,7 @@ permalink: /who-we-are/
 
 <p>The Met Office Informatics Lab combines scientists, software engineers, and designers to work closely together to come up with new ideas. We try to rapidly prototype non-business-as-usual ideas that allow people from without the Met Office get access to our information, expertise, and facilities.</p>
 
-<p>The core group works as part of the UK's <a href="www.metoffice.gov.uk">Met Office</a>, which is one of the world's <a href="http://www.metoffice.gov.uk/about-us/who/accuracy">leading operational weather forecasters</a> and <a href="http://www.metoffice.gov.uk/climate-guide/science/science-behind-climate-change/hadley">climate change research institutes</a>. However, we are really keen to work with anyone who has an interest and wants to collaborate on any of our projects.</p>
+<p>The core group works as part of the UK's <a href="http://www.metoffice.gov.uk">Met Office</a>, which is one of the world's <a href="http://www.metoffice.gov.uk/about-us/who/accuracy">leading operational weather forecasters</a> and <a href="http://www.metoffice.gov.uk/climate-guide/science/science-behind-climate-change/hadley">climate change research institutes</a>. However, we are really keen to work with anyone who has an interest and wants to collaborate on any of our projects.</p>
 
 <h2>Core members</h2>
 <p>These are the core members who work full time for the Lab.</p>


### PR DESCRIPTION
First is adding .travis.yml which tells Travis what to do.

Next is adding a Gemfile which specifies the requirements for the projects.
The downside of this is we will now have to use bundle for all commands
relating to the blog (no more jekyll serve). So the first time you work on
the blog you need to do a 'bundle install' to install the dependancies.
From then on you need to prefix your commands with 'bundle exec' so
you can serve with 'bundle exec jekyll serve'.

That however is a bit long winded so we will also have a Rakefile which
contains some commands which can be run by specifying 'rake <command>'.
So instead of 'bundle exec jekyll serve' we can do 'rake serve'. We can
also test the blog by running 'rake test' which is what Travis will be doing.