### PR TITLE
Deploy all commits on master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,4 +19,4 @@ deploy:
   skip_cleanup: true
   region: eu-west-1
   on:
-    tags: true
+    branch: master


### PR DESCRIPTION
Rather than tagging a release every time we want to deploy we will just deploy master whenever it changes. This makes more sense as the blog will change frequently and is not a product which has releases.